### PR TITLE
Implement service worker caching

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -1,13 +1,38 @@
-// Service Worker file
-self.addEventListener('install', (event) => {
-  console.log('Service Worker installed');
+const CACHE_VERSION = 'v1';
+const CACHE_NAME = `mctech-cache-${CACHE_VERSION}`;
+const ASSETS_TO_CACHE = [
+  '/assets/css/main.min.css',
+  '/assets/js/main.min.js',
+  '/assets/images/logo.jpg',
+  '/assets/images/logo.webp'
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(ASSETS_TO_CACHE))
+  );
+  self.skipWaiting();
 });
 
-self.addEventListener('activate', (event) => {
-  console.log('Service Worker activated');
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(names => Promise.all(
+      names.filter(name => name !== CACHE_NAME).map(name => caches.delete(name))
+    ))
+  );
+  self.clients.claim();
 });
 
-self.addEventListener('fetch', (event) => {
-  console.log('Fetch event for ', event.request.url);
-  event.respondWith(fetch(event.request));
+self.addEventListener('fetch', event => {
+  if (event.request.method !== 'GET') return;
+  event.respondWith(
+    caches.match(event.request).then(cached => {
+      if (cached) return cached;
+      return fetch(event.request).then(response => {
+        const respClone = response.clone();
+        caches.open(CACHE_NAME).then(cache => cache.put(event.request, respClone));
+        return response;
+      });
+    })
+  );
 });


### PR DESCRIPTION
## Summary
- pre-cache CSS, JS and image assets
- serve cached content first and update from network
- clear old caches on activate with a versioned cache name

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6858bee0b8d8833382d899979a335531